### PR TITLE
Implement upgrade GUI plugin

### DIFF
--- a/NEED.md
+++ b/NEED.md
@@ -1,0 +1,10 @@
+The plugin requires obtaining the MMOItems item type from an `ItemStack` to match
+whitelist entries of format `TYPE;;ID`. The current UniItem `MMOItemsProvider`
+API only exposes `id(ItemStack)` without a corresponding method to fetch the type.
+It would be helpful for `DrcomoCoreLib` or UniItem to provide:
+
+```
+@Nullable String type(@NotNull ItemStack item);
+```
+
+so whitelist validation can be accurate without relying on NBT parsing.

--- a/src/main/java/cn/drcomo/drcomoupgradeguimi/DrcomoUpgradeGUIMI.java
+++ b/src/main/java/cn/drcomo/drcomoupgradeguimi/DrcomoUpgradeGUIMI.java
@@ -1,17 +1,57 @@
 package cn.drcomo.drcomoupgradeguimi;
 
+import cn.drcomo.corelib.config.YamlUtil;
+import cn.drcomo.corelib.gui.GUISessionManager;
+import cn.drcomo.corelib.gui.GuiManager;
+import cn.drcomo.corelib.message.MessageService;
+import cn.drcomo.corelib.util.DebugUtil;
+import cn.drcomo.corelib.hook.placeholder.PlaceholderAPIUtil;
+import cn.drcomo.drcomoupgradeguimi.command.MainCommand;
+import cn.drcomo.drcomoupgradeguimi.config.ConfigManager;
+import cn.drcomo.drcomoupgradeguimi.gui.UpgradeGui;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.plugin.Plugin;
 
 public final class DrcomoUpgradeGUIMI extends JavaPlugin {
 
+    private DebugUtil logger;
+    private YamlUtil yamlUtil;
+    private MessageService messages;
+    private GUISessionManager sessionManager;
+    private GuiManager guiManager;
+    private ConfigManager config;
+    private UpgradeGui upgradeGui;
+
     @Override
     public void onEnable() {
-        // Plugin startup logic
+        logger = new DebugUtil(this, DebugUtil.LogLevel.INFO);
+        yamlUtil = new YamlUtil(this, logger);
+        yamlUtil.copyDefaults("", "");
+        yamlUtil.loadConfig("config");
+        yamlUtil.loadConfig("lang");
+        config = new ConfigManager(yamlUtil, logger);
+        config.reload();
+        logger.setLevel(config.getLogLevel());
 
+        PlaceholderAPIUtil papi = new PlaceholderAPIUtil(this, getName().toLowerCase());
+        messages = new MessageService(this, logger, yamlUtil, papi, "lang", "");
+        messages.reloadLanguages();
+
+        guiManager = new GuiManager(logger);
+        sessionManager = new GUISessionManager(this, logger, messages);
+        upgradeGui = new UpgradeGui(guiManager, sessionManager, config, logger);
+
+        getServer().getPluginManager().registerEvents(new cn.drcomo.drcomoupgradeguimi.listener.GuiClickListener(sessionManager, guiManager, config, logger, messages), this);
+        getServer().getPluginManager().registerEvents(new cn.drcomo.drcomoupgradeguimi.listener.GuiDragListener(sessionManager, guiManager, config, messages), this);
+        getServer().getPluginManager().registerEvents(new cn.drcomo.drcomoupgradeguimi.listener.GuiCloseListener(sessionManager, guiManager, messages, upgradeGui), this);
+
+        getCommand("drcomoupgrade").setExecutor(new MainCommand(upgradeGui, config, messages, logger));
     }
 
     @Override
     public void onDisable() {
-        // Plugin shutdown logic
+        if (sessionManager != null) {
+            sessionManager.closeAllSessions();
+        }
     }
 }

--- a/src/main/java/cn/drcomo/drcomoupgradeguimi/command/MainCommand.java
+++ b/src/main/java/cn/drcomo/drcomoupgradeguimi/command/MainCommand.java
@@ -1,0 +1,49 @@
+package cn.drcomo.drcomoupgradeguimi.command;
+
+import cn.drcomo.corelib.message.MessageService;
+import cn.drcomo.corelib.util.DebugUtil;
+import cn.drcomo.drcomoupgradeguimi.config.ConfigManager;
+import cn.drcomo.drcomoupgradeguimi.gui.UpgradeGui;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * Handle plugin commands.
+ */
+public class MainCommand implements CommandExecutor {
+    private final UpgradeGui upgradeGui;
+    private final ConfigManager config;
+    private final MessageService messages;
+    private final DebugUtil logger;
+
+    public MainCommand(UpgradeGui upgradeGui, ConfigManager config,
+                       MessageService messages, DebugUtil logger) {
+        this.upgradeGui = upgradeGui;
+        this.config = config;
+        this.messages = messages;
+        this.logger = logger;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length == 0 || args[0].equalsIgnoreCase("open")) {
+            if (sender instanceof Player player) {
+                upgradeGui.open(player);
+            } else {
+                sender.sendMessage("Only players can use this command.");
+            }
+            return true;
+        }
+        if (args[0].equalsIgnoreCase("reload")) {
+            config.reload();
+            messages.reloadLanguages();
+            upgradeGui.rebuild();
+            logger.setLevel(config.getLogLevel());
+            messages.send(sender, "reload-complete");
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/cn/drcomo/drcomoupgradeguimi/config/ConfigManager.java
+++ b/src/main/java/cn/drcomo/drcomoupgradeguimi/config/ConfigManager.java
@@ -1,0 +1,119 @@
+package cn.drcomo.drcomoupgradeguimi.config;
+
+import cn.drcomo.corelib.config.YamlUtil;
+import cn.drcomo.corelib.util.DebugUtil;
+import cn.drcomo.corelib.util.DebugUtil.LogLevel;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.*;
+
+/**
+ * Manage plugin configuration and provide accessors.
+ */
+public class ConfigManager {
+    private final YamlUtil yamlUtil;
+    private final DebugUtil logger;
+    private Set<String> whitelist = new HashSet<>();
+    private GuiConfig guiConfig;
+    private LogLevel logLevel = LogLevel.INFO;
+
+    public ConfigManager(YamlUtil yamlUtil, DebugUtil logger) {
+        this.yamlUtil = yamlUtil;
+        this.logger = logger;
+    }
+
+    /** Reload config.yml and parse fields. */
+    public void reload() {
+        yamlUtil.reloadConfig("config");
+        parse();
+    }
+
+    private void parse() {
+        whitelist.clear();
+        whitelist.addAll(yamlUtil.getStringList("config", "whitelist", Collections.emptyList()));
+        logLevel = LogLevel.valueOf(yamlUtil.getString("config", "debug-level", "INFO").toUpperCase());
+
+        String title = yamlUtil.getString("config", "gui.title", "&8物品升级界面");
+        int size = yamlUtil.getInt("config", "gui.size", 27);
+        Set<Integer> decorativeSlots = new HashSet<>();
+        Map<Integer, ItemStack> decorativeItems = new HashMap<>();
+        ConfigurationSection decoSec = yamlUtil.getSection("config", "gui.decorative-slots");
+        if (decoSec != null) {
+            for (String key : decoSec.getKeys(false)) {
+                List<Integer> slots = parseSlots(key);
+                ItemStack item = itemFromSection(decoSec.getConfigurationSection(key));
+                for (int slot : slots) {
+                    decorativeSlots.add(slot);
+                    decorativeItems.put(slot, item);
+                }
+            }
+        }
+        int closeSlot = yamlUtil.getInt("config", "gui.close-button-slot", 22);
+        ItemStack closeItem = itemFromSection(yamlUtil.getSection("config", "gui.close-button"));
+        guiConfig = new GuiConfig(title, size, decorativeSlots, decorativeItems, closeSlot, closeItem);
+    }
+
+    private List<Integer> parseSlots(String key) {
+        String trimmed = key.replace("[", "").replace("]", "");
+        String[] parts = trimmed.split(",");
+        List<Integer> result = new ArrayList<>();
+        for (String part : parts) {
+            try {
+                result.add(Integer.parseInt(part.trim()));
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        return result;
+    }
+
+    private ItemStack itemFromSection(ConfigurationSection section) {
+        if (section == null) return new ItemStack(Material.BARRIER);
+        Material mat = Material.matchMaterial(section.getString("material", "BARRIER"));
+        ItemStack item = new ItemStack(mat == null ? Material.BARRIER : mat);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(color(section.getString("name", "")));
+            List<String> lore = section.getStringList("lore");
+            if (!lore.isEmpty()) {
+                meta.setLore(colorList(lore));
+            }
+            if (section.contains("custom-model-data")) {
+                meta.setCustomModelData(section.getInt("custom-model-data"));
+            }
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    private String color(String text) {
+        return cn.drcomo.corelib.color.ColorUtil.translateColors(text);
+    }
+
+    private List<String> colorList(List<String> list) {
+        List<String> res = new ArrayList<>();
+        for (String s : list) res.add(color(s));
+        return res;
+    }
+
+    public Set<String> getWhitelist() {
+        return whitelist;
+    }
+
+    public GuiConfig getGuiConfig() {
+        return guiConfig;
+    }
+
+    public LogLevel getLogLevel() {
+        return logLevel;
+    }
+
+    /** Holds parsed GUI configuration. */
+    public record GuiConfig(String title, int size, Set<Integer> decorativeSlots,
+                            Map<Integer, ItemStack> decorativeItems,
+                            int closeButtonSlot, ItemStack closeButtonItem) {
+    }
+}

--- a/src/main/java/cn/drcomo/drcomoupgradeguimi/gui/MMOItemUtil.java
+++ b/src/main/java/cn/drcomo/drcomoupgradeguimi/gui/MMOItemUtil.java
@@ -1,0 +1,29 @@
+package cn.drcomo.drcomoupgradeguimi.gui;
+
+import io.github.projectunified.uniitem.mmoitems.MMOItemsProvider;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Utility to upgrade MMOItems items using UniItem provider.
+ */
+public final class MMOItemUtil {
+
+    private MMOItemUtil() {
+    }
+
+    /**
+     * Upgrade given item to latest definition.
+     *
+     * @param item original item
+     * @return upgraded item or null if failed
+     */
+    @Nullable
+    public static ItemStack upgrade(ItemStack item) {
+        if (item == null) return null;
+        MMOItemsProvider provider = MMOItemsProvider.get();
+        String id = provider.id(item);
+        if (id == null) return null;
+        return provider.item(id);
+    }
+}

--- a/src/main/java/cn/drcomo/drcomoupgradeguimi/gui/UpgradeGui.java
+++ b/src/main/java/cn/drcomo/drcomoupgradeguimi/gui/UpgradeGui.java
@@ -1,0 +1,79 @@
+package cn.drcomo.drcomoupgradeguimi.gui;
+
+import cn.drcomo.corelib.gui.GUISessionManager;
+import cn.drcomo.corelib.gui.GuiManager;
+import cn.drcomo.corelib.util.DebugUtil;
+import cn.drcomo.drcomoupgradeguimi.config.ConfigManager;
+import cn.drcomo.drcomoupgradeguimi.config.ConfigManager.GuiConfig;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Create and manage upgrade GUI using template inventory.
+ */
+public class UpgradeGui {
+    public static final String SESSION_ID = "upgrade-gui";
+
+    private final GuiManager guiManager;
+    private final GUISessionManager sessionManager;
+    private final ConfigManager config;
+    private final DebugUtil logger;
+    private Inventory template;
+
+    public UpgradeGui(GuiManager guiManager, GUISessionManager sessionManager,
+                       ConfigManager config, DebugUtil logger) {
+        this.guiManager = guiManager;
+        this.sessionManager = sessionManager;
+        this.config = config;
+        this.logger = logger;
+        buildTemplate();
+    }
+
+    /** Rebuild template when config changes. */
+    public void rebuild() {
+        buildTemplate();
+    }
+
+    private void buildTemplate() {
+        GuiConfig cfg = config.getGuiConfig();
+        template = Bukkit.createInventory(null, cfg.size(), cfg.title());
+        for (Map.Entry<Integer, ItemStack> e : cfg.decorativeItems().entrySet()) {
+            template.setItem(e.getKey(), e.getValue());
+        }
+        template.setItem(cfg.closeButtonSlot(), cfg.closeButtonItem());
+    }
+
+    /** Open GUI for player. */
+    public void open(Player player) {
+        sessionManager.openSession(player, SESSION_ID, p -> template);
+        logger.debug("Open gui for " + player.getName());
+    }
+
+    /** Process all items inside inventory on close. */
+    public void processClose(Player player, Inventory inv) {
+        GuiConfig cfg = config.getGuiConfig();
+        for (int i = 0; i < inv.getSize(); i++) {
+            if (cfg.decorativeSlots().contains(i) || i == cfg.closeButtonSlot()) {
+                continue;
+            }
+            ItemStack item = inv.getItem(i);
+            if (item == null) continue;
+            handleItem(player, item);
+        }
+        player.updateInventory();
+    }
+
+    private void handleItem(Player player, ItemStack item) {
+        ItemStack upgraded = MMOItemUtil.upgrade(item);
+        ItemStack result = upgraded != null ? upgraded : item;
+        Map<Integer, ItemStack> leftover = player.getInventory().addItem(result);
+        if (!leftover.isEmpty()) {
+            leftover.values().forEach(it -> player.getWorld().dropItem(player.getLocation(), it));
+        }
+    }
+}

--- a/src/main/java/cn/drcomo/drcomoupgradeguimi/listener/GuiClickListener.java
+++ b/src/main/java/cn/drcomo/drcomoupgradeguimi/listener/GuiClickListener.java
@@ -1,0 +1,79 @@
+package cn.drcomo.drcomoupgradeguimi.listener;
+
+import cn.drcomo.corelib.gui.GUISessionManager;
+import cn.drcomo.corelib.gui.GuiManager;
+import cn.drcomo.corelib.util.DebugUtil;
+import cn.drcomo.drcomoupgradeguimi.config.ConfigManager;
+import cn.drcomo.corelib.message.MessageService;
+import io.github.projectunified.uniitem.mmoitems.MMOItemsProvider;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.entity.Player;
+
+import java.util.Set;
+
+/**
+ * Handle click events inside upgrade GUI.
+ */
+public class GuiClickListener implements Listener {
+    private final GUISessionManager sessionManager;
+    private final GuiManager guiManager;
+    private final ConfigManager config;
+    private final DebugUtil logger;
+    private final MessageService messages;
+
+    public GuiClickListener(GUISessionManager sessionManager, GuiManager guiManager,
+                            ConfigManager config, DebugUtil logger, MessageService messages) {
+        this.sessionManager = sessionManager;
+        this.guiManager = guiManager;
+        this.config = config;
+        this.logger = logger;
+        this.messages = messages;
+    }
+
+    @EventHandler
+    public void onClick(InventoryClickEvent e) {
+        Player player = (Player) e.getWhoClicked();
+        Inventory inv = e.getInventory();
+        if (!sessionManager.validateSessionInventory(player, inv)) {
+            return;
+        }
+        e.setCancelled(true);
+        ConfigManager.GuiConfig gui = config.getGuiConfig();
+        int slot = e.getRawSlot();
+        if (slot == gui.closeButtonSlot()) {
+            player.closeInventory();
+            return;
+        }
+        if (gui.decorativeSlots().contains(slot)) {
+            return;
+        }
+        ItemStack current = e.getCursor();
+        if (current == null || current.getType().isAir()) {
+            e.setCancelled(false);
+            return;
+        }
+        if (isWhitelisted(current)) {
+            e.setCancelled(false);
+        } else {
+            messages.send(player, "invalid-item");
+            guiManager.clearCursor(player, e);
+        }
+    }
+
+    private boolean isWhitelisted(ItemStack item) {
+        String id = MMOItemsProvider.get().id(item);
+        if (id == null) return false;
+        Set<String> w = config.getWhitelist();
+        for (String s : w) {
+            if (s.endsWith(";;" + id)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/cn/drcomo/drcomoupgradeguimi/listener/GuiCloseListener.java
+++ b/src/main/java/cn/drcomo/drcomoupgradeguimi/listener/GuiCloseListener.java
@@ -1,0 +1,40 @@
+package cn.drcomo.drcomoupgradeguimi.listener;
+
+import cn.drcomo.corelib.gui.GUISessionManager;
+import cn.drcomo.corelib.gui.GuiManager;
+import cn.drcomo.corelib.message.MessageService;
+import cn.drcomo.drcomoupgradeguimi.gui.UpgradeGui;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+
+/**
+ * Handle inventory close event to process upgrading.
+ */
+public class GuiCloseListener implements Listener {
+    private final GUISessionManager sessionManager;
+    private final GuiManager guiManager;
+    private final MessageService messages;
+    private final UpgradeGui gui;
+
+    public GuiCloseListener(GUISessionManager sessionManager, GuiManager guiManager,
+                            MessageService messages, UpgradeGui gui) {
+        this.sessionManager = sessionManager;
+        this.guiManager = guiManager;
+        this.messages = messages;
+        this.gui = gui;
+    }
+
+    @EventHandler
+    public void onClose(InventoryCloseEvent e) {
+        Player player = (Player) e.getPlayer();
+        Inventory inv = e.getInventory();
+        if (!sessionManager.validateSessionInventory(player, inv)) {
+            return;
+        }
+        gui.processClose(player, inv);
+        sessionManager.closeSession(player);
+    }
+}

--- a/src/main/java/cn/drcomo/drcomoupgradeguimi/listener/GuiDragListener.java
+++ b/src/main/java/cn/drcomo/drcomoupgradeguimi/listener/GuiDragListener.java
@@ -1,0 +1,65 @@
+package cn.drcomo.drcomoupgradeguimi.listener;
+
+import cn.drcomo.corelib.gui.GUISessionManager;
+import cn.drcomo.corelib.gui.GuiManager;
+import cn.drcomo.corelib.message.MessageService;
+import cn.drcomo.drcomoupgradeguimi.config.ConfigManager;
+import io.github.projectunified.uniitem.mmoitems.MMOItemsProvider;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Set;
+
+/**
+ * Handle drag events for upgrade GUI.
+ */
+public class GuiDragListener implements Listener {
+    private final GUISessionManager sessionManager;
+    private final GuiManager guiManager;
+    private final ConfigManager config;
+    private final MessageService messages;
+
+    public GuiDragListener(GUISessionManager sessionManager, GuiManager guiManager,
+                           ConfigManager config, MessageService messages) {
+        this.sessionManager = sessionManager;
+        this.guiManager = guiManager;
+        this.config = config;
+        this.messages = messages;
+    }
+
+    @EventHandler
+    public void onDrag(InventoryDragEvent e) {
+        Player player = (Player) e.getWhoClicked();
+        Inventory inv = e.getInventory();
+        if (!sessionManager.validateSessionInventory(player, inv)) {
+            return;
+        }
+        ConfigManager.GuiConfig gui = config.getGuiConfig();
+        for (int slot : e.getRawSlots()) {
+            if (gui.decorativeSlots().contains(slot) || slot == gui.closeButtonSlot()) {
+                e.setCancelled(true);
+                return;
+            }
+        }
+        ItemStack item = e.getOldCursor();
+        if (item != null && !item.getType().isAir() && !isWhitelisted(item)) {
+            e.setCancelled(true);
+            messages.send(player, "invalid-item");
+            guiManager.clearCursor(player, null);
+        }
+    }
+
+    private boolean isWhitelisted(ItemStack item) {
+        String id = MMOItemsProvider.get().id(item);
+        if (id == null) return false;
+        Set<String> w = config.getWhitelist();
+        for (String s : w) {
+            if (s.endsWith(";;" + id)) return true;
+        }
+        return false;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,24 @@
+whitelist:
+  - "CLASS;;铸刃者情报"
+  - "WEAPON;;神圣之剑"
+
+gui:
+  title: "&8物品升级界面"
+  size: 27
+  decorative-slots:
+    "[0,1,2,3,5,6,7,8]":
+      material: GRAY_STAINED_GLASS_PANE
+      name: "&7"
+    "[18,26]":
+      material: LIGHT_GRAY_STAINED_GLASS_PANE
+      name: "&8边缘"
+      lore:
+        - "&7这只是个边框"
+  close-button-slot: 22
+  close-button:
+    material: BARRIER
+    name: "&c关闭升级界面"
+    lore:
+      - "&7点击关闭界面"
+
+debug-level: INFO

--- a/src/main/resources/lang.yml
+++ b/src/main/resources/lang.yml
@@ -1,0 +1,2 @@
+invalid-item: "&c该物品无法放入升级界面！"
+reload-complete: "&a配置已重载。"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,3 +3,7 @@ version: '1.0'
 main: cn.drcomo.drcomoupgradeguimi.DrcomoUpgradeGUIMI
 api-version: '1.18'
 authors: [ BaiMo_ ]
+commands:
+  drcomoupgrade:
+    description: Upgrade items or reload config
+    usage: /<command> [open|reload]


### PR DESCRIPTION
## Summary
- implement full upgrade GUI logic with ConfigManager, UpgradeGui, and listeners
- support commands to open GUI and reload config
- provide default config and language files
- document missing API capability in NEED.md

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871e5c7b6a08330bd1fe413e396b621