### PR TITLE
Fix GUI slot handling for decorative and close items

### DIFF
--- a/src/main/java/cn/drcomo/drcomoupgradeguimi/listener/GuiClickListener.java
+++ b/src/main/java/cn/drcomo/drcomoupgradeguimi/listener/GuiClickListener.java
@@ -55,15 +55,12 @@ public class GuiClickListener implements Listener {
             guiCfg = config.getGuiConfig();
             int rawSlot = e.getRawSlot();
             if (rawSlot == guiCfg.closeButtonSlot() || guiCfg.decorativeSlots().contains(rawSlot)) {
-                ItemStack cursor = e.getCursor();
-                if (cursor != null && !cursor.getType().isAir()) {
-                    // 玩家手上有物品时，直接取消并提示，防止物品被吞
-                    e.setCancelled(true);
-                    return;
+                e.setCancelled(true);
+                if (rawSlot == guiCfg.closeButtonSlot()) {
+                    ClickContext ctx = ClickContext.from(e, sessionManager);
+                    dispatcher.handleClick(ctx, e);
                 }
-                ClickContext ctx = ClickContext.from(e, sessionManager);
-                dispatcher.handleClick(ctx, e);
-                return; // 已处理完毕
+                return; // 已处理完毕或被拦截
             }
         }
 


### PR DESCRIPTION
## Summary
- prevent players taking decorative or close button items from GUI

## Testing
- `apt-get update -y` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687f8be4ba6c83309bfecf9d19f64216